### PR TITLE
Pass additionally supported native arguments to the SauceLabsTunnel p…

### DIFF
--- a/SauceLabsTunnel.js
+++ b/SauceLabsTunnel.js
@@ -11,7 +11,7 @@ var Tunnel = require('./Tunnel');
 var urlUtil = require('url');
 var util = require('./util');
 
-var SC_VERSION = '4.3';
+var SC_VERSION = '4.3.13';
 
 /**
  * A Sauce Labs tunnel. This tunnel uses Sauce Connect 4 on platforms where it is supported, and Sauce Connect 3
@@ -287,7 +287,7 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 
 		this.logFileSize && args.push('-g', this.logFileSize);
 		this.squidOptions && args.push('-S', this.squidOptions);
-		this.vmVersion && args.push('-V', this.vmVersion);
+		this.vmVersion && args.push('--vm-version', this.vmVersion);
 		this.restUrl && args.push('-x', this.restUrl);
 		this.verbose && args.push('-d');
 		this.directDomains.length && args.push('-D', this.directDomains.join(','));

--- a/SauceLabsTunnel.js
+++ b/SauceLabsTunnel.js
@@ -250,9 +250,6 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 			});
 		}
 
-		this.logTrafficStats && args.push('-z', Math.floor(this.logTrafficStats / 1000));
-		this.verbose && args.push('-v');
-
 		return args;
 	},
 
@@ -262,12 +259,6 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 			this.username,
 			this.accessKey
 		];
-
-		this.logFileSize && args.push('-g', this.logFileSize);
-		this.squidOptions && args.push('-S', this.squidOptions);
-		this.vmVersion && args.push('-V', this.vmVersion);
-		this.restUrl && args.push('-x', this.restUrl);
-		this.verbose && args.push('-d');
 
 		if (proxy) {
 			proxy.hostname && args.push('-p', proxy.hostname + (proxy.port ? ':' + proxy.port : ''));
@@ -294,6 +285,11 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 			'-f', readyFile
 		);
 
+		this.logFileSize && args.push('-g', this.logFileSize);
+		this.squidOptions && args.push('-S', this.squidOptions);
+		this.vmVersion && args.push('-V', this.vmVersion);
+		this.restUrl && args.push('-x', this.restUrl);
+		this.verbose && args.push('-d');
 		this.directDomains.length && args.push('-D', this.directDomains.join(','));
 		this.tunnelDomains.length && args.push('-t', this.tunnelDomains.join(','));
 		this.fastFailDomains.length && args.push('-F', this.fastFailDomains.join(','));


### PR DESCRIPTION
Moved common args that were previously java specific to general arg creation. These are verified to be available in the OSX native client.