### PR TITLE
Added support for version ranges

### DIFF
--- a/BrowserStackTunnel.js
+++ b/BrowserStackTunnel.js
@@ -94,6 +94,8 @@ BrowserStackTunnel.prototype = util.mixin(Object.create(_super), /** @lends modu
 	 */
 	username: null,
 
+	getEnvironmentUrl: 'https://www.browserstack.com/automate/browsers.json',
+
 	get auth() {
 		return this.username + ':' + this.accessKey;
 	},

--- a/BrowserStackTunnel.js
+++ b/BrowserStackTunnel.js
@@ -256,6 +256,23 @@ BrowserStackTunnel.prototype = util.mixin(Object.create(_super), /** @lends modu
 		}, 5000);
 
 		return dfd.promise;
+	},
+
+	/**
+	 * Get a list of environments available on the service
+	 */
+	getEnvironments: function () {
+		return Tunnel.prototype.getEnvironments.call(this)
+			.then(function (environments) {
+				return environments.map(function (environment) {
+					return {
+						browserName: environment.browser,
+						version: environment.browser_version,
+						platform: environment.os,
+						descriptor: environment
+					};
+				});
+			});
 	}
 });
 

--- a/BrowserStackTunnel.js
+++ b/BrowserStackTunnel.js
@@ -259,21 +259,30 @@ BrowserStackTunnel.prototype = util.mixin(Object.create(_super), /** @lends modu
 	},
 
 	/**
-	 * Get a list of environments available on the service
+	 * Attempt to normalize a BrowserStack described environment with the standard Selenium capabilities
+	 * 
+	 * BrowserStack returns a list of environments that looks like:
+	 *
+	 * {
+	 *   "browser": "opera",
+	 *   "os_version": "Lion",
+	 *   "browser_version":"12.15",
+	 *   "device": null,
+	 *   "os": "OS X"
+	 * }
+	 * 
+	 * @param environment a BrowserStack environment descriptor
+	 * @private
 	 */
-	getEnvironments: function () {
-		return Tunnel.prototype.getEnvironments.call(this)
-			.then(function (environments) {
-				return environments.map(function (environment) {
-					return {
-						browserName: environment.browser,
-						version: environment.browser_version,
-						platform: environment.os,
-						descriptor: environment
-					};
-				});
-			});
+	_normalizeEnvironment: function (environment) {
+		return {
+			platform: environment.os.toLowerCase(),
+			browserName: environment.browser.toLowerCase(),
+			version: environment.browser_version,
+			descriptor: environment
+		};
 	}
 });
+
 
 module.exports = BrowserStackTunnel;

--- a/Capabilities.js
+++ b/Capabilities.js
@@ -1,0 +1,15 @@
+define([], function () {
+	return {
+		browserName: [
+			'chrome',
+			'firefox',
+			'safari'
+		],
+
+		platformName: [
+			'windows',
+			'mac',
+			'linux'
+		]
+	};
+});

--- a/SauceLabsTunnel.js
+++ b/SauceLabsTunnel.js
@@ -458,6 +458,23 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 		}));
 
 		return child;
+	},
+
+	/**
+	 * Get a list of environments available on the service
+	 */
+	getEnvironments: function () {
+		return Tunnel.prototype.getEnvironments.call(this)
+			.then(function (environments) {
+				return environments.map(function (environment) {
+					return {
+						browserName: environment.api_name,
+						version: environment.short_version,
+						platform: environment.os,
+						descriptor: environment
+					};
+				});
+			});
 	}
 });
 

--- a/SauceLabsTunnel.js
+++ b/SauceLabsTunnel.js
@@ -461,20 +461,30 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 	},
 
 	/**
-	 * Get a list of environments available on the service
+	 * Attempt to normalize a SauceLabs described environment with the standard Selenium capabilities
+	 *
+	 * SauceLabs returns a list of environments that looks like:
+	 *
+	 * {
+	 *   "short_version": "25",
+	 *   "long_name": "Firefox",
+	 *   "api_name": "firefox",
+	 *   "long_version": "25.0b2.",
+	 *   "latest_stable_version": "",
+	 *   "automation_backend": "webdriver",
+	 *   "os": "Windows 2003"
+	 *   }
+	 *
+	 * @param environment a SauceLabs environment descriptor
+	 * @private
 	 */
-	getEnvironments: function () {
-		return Tunnel.prototype.getEnvironments.call(this)
-			.then(function (environments) {
-				return environments.map(function (environment) {
-					return {
-						browserName: environment.api_name,
-						version: environment.short_version,
-						platform: environment.os,
-						descriptor: environment
-					};
-				});
-			});
+	_normalizeEnvironment: function (environment) {
+		return {
+			browserName: environment.api_name.toLowerCase(),
+			version: environment.short_version,
+			platform: environment.os.toLowerCase(),
+			descriptor: environment
+		};
 	}
 });
 

--- a/SauceLabsTunnel.js
+++ b/SauceLabsTunnel.js
@@ -163,6 +163,8 @@ SauceLabsTunnel.prototype = util.mixin(Object.create(_super), /** @lends module:
 	 */
 	vmVersion: null,
 
+	getEnvironmentUrl: 'https://saucelabs.com/rest/v1/info/platforms/webdriver',
+
 	get auth() {
 		return this.username + ':' + this.accessKey;
 	},

--- a/TestingBotTunnel.js
+++ b/TestingBotTunnel.js
@@ -99,6 +99,8 @@ TestingBotTunnel.prototype = util.mixin(Object.create(_super), /** @lends module
 	 */
 	useSsl: false,
 
+	getEnvironmentUrl: 'https://api.testingbot.com/v1/browsers',
+
 	get auth() {
 		return this.apiKey + ':' + this.apiSecret;
 	},

--- a/TestingBotTunnel.js
+++ b/TestingBotTunnel.js
@@ -218,6 +218,23 @@ TestingBotTunnel.prototype = util.mixin(Object.create(_super), /** @lends module
 		);
 
 		return child;
+	},
+
+	/**
+	 * Get a list of environments available on the service
+	 */
+	getEnvironments: function () {
+		return Tunnel.prototype.getEnvironments.call(this)
+			.then(function (environments) {
+				return environments.map(function (environment) {
+					return {
+						browserName: environment.name,
+						version: environment.version,
+						platform: environment.platform,
+						descriptor: environment
+					};
+				});
+			});
 	}
 });
 

--- a/TestingBotTunnel.js
+++ b/TestingBotTunnel.js
@@ -221,20 +221,34 @@ TestingBotTunnel.prototype = util.mixin(Object.create(_super), /** @lends module
 	},
 
 	/**
-	 * Get a list of environments available on the service
+	 * Attempt to normalize a TestingBot described environment with the standard Selenium capabilities
+	 *
+	 * TestingBot returns a list of environments that looks like:
+	 *
+	 * {
+	 *   "selenium_name": "Galaxy Nexus",
+	 *   "name": "galaxy_nexus",
+	 *   "platform": "ANDROID",
+	 *   "version":"0"
+	 * },
+	 * 
+	 * {
+	 *   "selenium_name": "Chrome36",
+	 *   "name": "googlechrome",
+	 *   "platform": "CAPITAN",
+	 *   "version":"36"
+	 * }
+	 *
+	 * @param environment a TestingBot environment descriptor
+	 * @private
 	 */
-	getEnvironments: function () {
-		return Tunnel.prototype.getEnvironments.call(this)
-			.then(function (environments) {
-				return environments.map(function (environment) {
-					return {
-						browserName: environment.name,
-						version: environment.version,
-						platform: environment.platform,
-						descriptor: environment
-					};
-				});
-			});
+	_normalizeEnvironment: function (environment) {
+		return {
+			platform: environment.platform.toLowerCase(),
+			browserName: environment.name.toLowerCase(),
+			version: environment.version,
+			descriptor: environment
+		};
 	}
 });
 

--- a/Tunnel.js
+++ b/Tunnel.js
@@ -586,18 +586,30 @@ Tunnel.prototype = util.mixin(Object.create(_super), /** @lends module:digdug/Tu
 	 * @return An object containing the response and helper functions
 	 */
 	getEnvironments: function () {
+		var normalizeEnvironment = this._normalizeEnvironment.bind(this);
+
 		return sendRequest(this.getEnvironmentUrl, {
 			password: this.accessKey,
 			user: this.username,
 			proxy: this.proxy
 		}).then(function (response) {
 			if (response.statusCode >= 200 && response.statusCode < 400) {
-				return JSON.parse(response.data.toString());
+				return JSON.parse(response.data.toString()).map(normalizeEnvironment)
 			}
 			else {
 				throw new Error('Server replied with a status of ' + response.statusCode);
 			}
 		});
+	},
+
+	/**
+	 * Normalizes a specific Tunnel environment descriptor to a general form. To be overriden by a child implementation.
+	 * @param environment an environment descriptor specific to the Tunnel
+	 * @return a normalized environment
+	 * @protected
+	 */
+	_normalizeEnvironment: function (environment) {
+		return environment;
 	}
 });
 

--- a/Tunnel.js
+++ b/Tunnel.js
@@ -11,7 +11,6 @@ var sendRequest = require('dojo/request');
 var spawnUtil = require('child_process');
 var urlUtil = require('url');
 var util = require('./util');
-var request = require('dojo/request');
 
 // TODO: Spawned processes are not getting cleaned up if there is a crash
 
@@ -570,10 +569,24 @@ Tunnel.prototype = util.mixin(Object.create(_super), /** @lends module:digdug/Tu
 	},
 
 	/**
-	 * Get a list of environments available on the service
+	 * Get a list of environments available on the service.
+	 *
+	 * This method should be overridden and use a specific implementation that returns normalized
+	 * environments from the service. E.g.
+	 *
+	 * {
+	 * 	browserName: 'firefox',
+	 * 	version: '12',
+	 * 	platform: 'windows',
+	 * 	descriptor: { <original returned environment> }
+	 * }
+	 *
+	 * NOTE: browserName and platform should be normalized to lower case.
+	 *
+	 * @return An object containing the response and helper functions
 	 */
 	getEnvironments: function () {
-		return request(this.getEnvironmentUrl, {
+		return sendRequest(this.getEnvironmentUrl, {
 			password: this.accessKey,
 			user: this.username,
 			proxy: this.proxy
@@ -585,127 +598,6 @@ Tunnel.prototype = util.mixin(Object.create(_super), /** @lends module:digdug/Tu
 				throw new Error('Server replied with a status of ' + response.statusCode);
 			}
 		});
-	},
-
-	/**
-	 * @param browser the browser name to filter by
-	 *
-	 * @return {Promise<U>} a list of unique, numeric versions filtered by browser
-	 */
-	getVersions: function (browser) {
-		function reduceVersions(list, environment) {
-			var version = environment.browser_version || environment.version || environment.short_version;
-
-			if (!isNaN(Number(version)) &&
-				this._matchEnvironment(environment, browser) &&
-				!versionSet.hasOwnProperty(version)) {
-				versionSet[version] = environment;
-				list.push(version);
-			}
-			return list;
-		}
-
-		var versionSet = {};
-
-		return this.getEnvironments()
-			.then(function (environments) {
-				return environments
-					.reduce(reduceVersions.bind(this), [])
-					.sort(this._compareVersionStrings);
-			}.bind(this));
-	},
-
-	_matchEnvironment: function (environment, browser) {
-		var normalizedBrowser = (environment.browser || environment.name || environment.api_name).toLowerCase();
-
-		return browser.toLowerCase() === normalizedBrowser;
-	},
-
-	/**
-	 * Take a version string which may contain a range or version aliases and returns a list of individual versions
-	 * for use with the tunnel service
-	 *
-	 * Supported version types and ranges:
-	 *
-	 * single version: 9
-	 * ranged version: 9..11
-	 * latest keyword: latest
-	 * previous keyword: previous
-	 * ranged version with alias: 9..latest
-	 * mathed version alias: latest-2
-	 * ranged mathed version alias: latest-2...latest
-	 *
-	 * @param versions a version string
-	 * @param browser {string} the name of the target browser
-	 * @param platform {string} [undefined] An optional platform target
-	 * @return {Array<string>} a list of individual version numbers for the specific target
-	 */
-	parseVersions: function (versions, browser) {
-		function splitVersions(versions) {
-			versions = versions.split('..').map(function (version) {
-				return version.trim();
-			});
-
-			if (versions.length > 2) {
-				throw new Error('Invalid version syntax');
-			}
-
-			return versions;
-		}
-
-		function expandVersionRange(left, right, availableVersions) {
-			left = parseInt(left, 10);
-			right = parseInt(right, 10);
-			return availableVersions.filter(function (version) {
-				version = parseInt(version, 10);
-
-				return !isNaN(version) && version >= left && version <= right;
-			});
-		}
-
-		if (!isNaN(Number(versions))) {
-			// avoid making an API service call for single version numbers
-			return Promise.resolve([ versions ]);
-		}
-
-		var self = this;
-		return this.getVersions(browser)
-			.then(function (availableVersions) {
-				versions = splitVersions(versions)
-					.map(self._resolveVersionAlias.bind(self, availableVersions))
-					.sort(self._compareVersionStrings);
-
-				if (versions.length === 2) {
-					versions = expandVersionRange(versions[0], versions[1], availableVersions);
-				}
-
-				return versions;
-			});
-	},
-
-	_resolveVersionAlias: function (versions, version) {
-		var pieces = version.split('-').map(function (version) {
-			return version.trim();
-		});
-
-		if (pieces[0] !== 'previous' && pieces[0] !== 'latest') {
-			return version;
-		}
-
-		var offset = pieces[0] === 'previous' ? 2 : 1;
-
-		if (pieces.length === 2) {
-			offset += Number(pieces[1]);
-		}
-
-		if (offset > versions.length) {
-			throw new Error(version + ' is out of bounds. Only ' + versions.length + ' available');
-		}
-		return versions[versions.length - offset];
-	},
-
-	_compareVersionStrings: function (a, b) {
-		return parseFloat(a) - parseFloat(b);
 	}
 });
 

--- a/tests/integration/BrowserStackTunnel.js
+++ b/tests/integration/BrowserStackTunnel.js
@@ -1,90 +1,30 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
-	'intern/dojo/node!../../BrowserStackTunnel',
-	'intern/dojo/Promise'
+	'./common',
+	'intern/dojo/node!../../BrowserStackTunnel'
 ], function (
 	registerSuite,
 	assert,
-	BrowserStackTunnel,
-	Promise
+	createCommonTests,
+	BrowserStackTunnel
 ) {
-	var tunnel;
-	var missingCredentials;
+	function assertBrowserStackEnvironment(environment) {
+		assert.property(environment, 'os_version');
+		assert.property(environment, 'browser');
+		assert.property(environment, 'os');
+		assert.property(environment, 'device');
+		assert.property(environment, 'browser_version');
+	}
 
-	registerSuite({
-		name: 'integration/BrowserStack',
-
-		beforeEach: function () {
-			tunnel = new BrowserStackTunnel();
-			missingCredentials = !tunnel.accessKey || !tunnel.username;
+	var commonTests = createCommonTests(BrowserStackTunnel, {
+		assertDescriptor: assertBrowserStackEnvironment,
+		requirementsCheck: function (tunnel) {
+			return !!tunnel.accessKey && !!tunnel.username;
 		},
-
-		getEnvironments: function () {
-			if (missingCredentials) {
-				this.skip('missing credentials. Please provide BrowserStack credentials with the ' +
-					'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables');
-				return;
-			}
-			return tunnel.getEnvironments()
-				.then(function (browsers) {
-					assert.isArray(browsers);
-					browsers.forEach(function (environment) {
-						assert.property(environment, 'os_version');
-						assert.property(environment, 'browser');
-						assert.property(environment, 'os');
-						assert.property(environment, 'device');
-						assert.property(environment, 'browser_version');
-					});
-				});
-		},
-
-		parseVersions: (function () {
-			var availableVersionsPromise;
-
-			return {
-				before: function () {
-					if (!missingCredentials) {
-						availableVersionsPromise = tunnel.getVersions('chrome');
-					}
-				},
-
-				latest: function () {
-					if (missingCredentials) {
-						this.skip('missing credentials. Please provide BrowserStack credentials with the ' +
-							'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables');
-						return;
-					}
-
-					return Promise.all([
-						tunnel.parseVersions('latest', 'chrome'),
-						availableVersionsPromise
-					]).then(function (results) {
-						var versions = results[0];
-						var availableVersions = results[1];
-						assert.lengthOf(versions, 1);
-						assert.deepEqual(versions, availableVersions.slice(-1));
-					});
-				},
-
-				'latest - 2 .. latest': function () {
-					if (missingCredentials) {
-						this.skip('missing credentials. Please provide BrowserStack credentials with the ' +
-							'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables');
-						return;
-					}
-
-					return Promise.all([
-						tunnel.parseVersions('latest - 2 .. latest', 'chrome'),
-						availableVersionsPromise
-					]).then(function (results) {
-						var versions = results[0];
-						var availableVersions = results[1];
-						assert.lengthOf(versions, 3);
-						assert.deepEqual(versions, availableVersions.slice(-3));
-					});
-				}
-			};
-		}())
+		missingRequirementsMessage: 'missing credentials. Please provide BrowserStack credentials with the ' +
+			'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables'
 	});
+	commonTests.name = 'integration/BrowserStackTunnel';
+	registerSuite(commonTests);
 });

--- a/tests/integration/BrowserStackTunnel.js
+++ b/tests/integration/BrowserStackTunnel.js
@@ -1,0 +1,90 @@
+define([
+	'intern!object',
+	'intern/chai!assert',
+	'intern/dojo/node!../../BrowserStackTunnel',
+	'intern/dojo/Promise'
+], function (
+	registerSuite,
+	assert,
+	BrowserStackTunnel,
+	Promise
+) {
+	var tunnel;
+	var missingCredentials;
+
+	registerSuite({
+		name: 'integration/BrowserStack',
+
+		beforeEach: function () {
+			tunnel = new BrowserStackTunnel();
+			missingCredentials = !tunnel.accessKey || !tunnel.username;
+		},
+
+		getEnvironments: function () {
+			if (missingCredentials) {
+				this.skip('missing credentials. Please provide BrowserStack credentials with the ' +
+					'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables');
+				return;
+			}
+			return tunnel.getEnvironments()
+				.then(function (browsers) {
+					assert.isArray(browsers);
+					browsers.forEach(function (environment) {
+						assert.property(environment, 'os_version');
+						assert.property(environment, 'browser');
+						assert.property(environment, 'os');
+						assert.property(environment, 'device');
+						assert.property(environment, 'browser_version');
+					});
+				});
+		},
+
+		parseVersions: (function () {
+			var availableVersionsPromise;
+
+			return {
+				before: function () {
+					if (!missingCredentials) {
+						availableVersionsPromise = tunnel.getVersions('chrome');
+					}
+				},
+
+				latest: function () {
+					if (missingCredentials) {
+						this.skip('missing credentials. Please provide BrowserStack credentials with the ' +
+							'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables');
+						return;
+					}
+
+					return Promise.all([
+						tunnel.parseVersions('latest', 'chrome'),
+						availableVersionsPromise
+					]).then(function (results) {
+						var versions = results[0];
+						var availableVersions = results[1];
+						assert.lengthOf(versions, 1);
+						assert.deepEqual(versions, availableVersions.slice(-1));
+					});
+				},
+
+				'latest - 2 .. latest': function () {
+					if (missingCredentials) {
+						this.skip('missing credentials. Please provide BrowserStack credentials with the ' +
+							'BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME environment variables');
+						return;
+					}
+
+					return Promise.all([
+						tunnel.parseVersions('latest - 2 .. latest', 'chrome'),
+						availableVersionsPromise
+					]).then(function (results) {
+						var versions = results[0];
+						var availableVersions = results[1];
+						assert.lengthOf(versions, 3);
+						assert.deepEqual(versions, availableVersions.slice(-3));
+					});
+				}
+			};
+		}())
+	});
+});

--- a/tests/integration/SauceLabsTunnel.js
+++ b/tests/integration/SauceLabsTunnel.js
@@ -1,0 +1,70 @@
+define([
+	'intern!object',
+	'intern/chai!assert',
+	'intern/dojo/node!../../SauceLabsTunnel',
+	'intern/dojo/Promise'
+], function (
+	registerSuite,
+	assert,
+	SauceLabsTunnel,
+	Promise
+) {
+	var tunnel;
+
+	registerSuite({
+		name: 'integration/SauceLabsTunnel',
+
+		beforeEach: function () {
+			tunnel = new SauceLabsTunnel();
+		},
+
+		getEnvironments: function () {
+			return tunnel.getEnvironments()
+				.then(function (browsers) {
+					assert.isArray(browsers);
+					browsers.forEach(function (environment) {
+						assert.property(environment, 'short_version');
+						assert.property(environment, 'long_name');
+						assert.property(environment, 'api_name');
+						assert.property(environment, 'long_version');
+						assert.property(environment, 'latest_stable_version');
+						assert.property(environment, 'automation_backend');
+						assert.property(environment, 'os');
+					});
+				});
+		},
+
+		parseVersions: (function () {
+			var availableVersionsPromise;
+
+			return {
+				before: function () {
+					availableVersionsPromise = tunnel.getVersions('chrome');
+				},
+
+				latest: function () {
+					return Promise.all([
+						tunnel.parseVersions('latest', 'chrome'),
+						availableVersionsPromise
+					]).then(function (results) {
+						var versions = results[0];
+						var availableVersions = results[1];
+						assert.lengthOf(versions, 1);
+						assert.deepEqual(versions, availableVersions.slice(-1));
+					});
+				},
+
+				'latest - 2 .. latest': function () {
+					return Promise.all([
+						tunnel.parseVersions('latest - 2 .. latest', 'chrome'),
+						availableVersionsPromise
+					]).then(function (results) {
+						var versions = results[0];
+						var availableVersions = results[1];
+						assert.deepEqual(versions, availableVersions.slice(-3));
+					});
+				}
+			};
+		}())
+	});
+});

--- a/tests/integration/SauceLabsTunnel.js
+++ b/tests/integration/SauceLabsTunnel.js
@@ -1,70 +1,27 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
-	'intern/dojo/node!../../SauceLabsTunnel',
-	'intern/dojo/Promise'
+	'./common',
+	'intern/dojo/node!../../SauceLabsTunnel'
 ], function (
 	registerSuite,
 	assert,
-	SauceLabsTunnel,
-	Promise
+	createCommonTests,
+	SauceLabsTunnel
 ) {
-	var tunnel;
+	function assertSauceLabsEnvironment(environment) {
+		assert.property(environment, 'short_version');
+		assert.property(environment, 'long_name');
+		assert.property(environment, 'api_name');
+		assert.property(environment, 'long_version');
+		assert.property(environment, 'latest_stable_version');
+		assert.property(environment, 'automation_backend');
+		assert.property(environment, 'os');
+	}
 
-	registerSuite({
-		name: 'integration/SauceLabsTunnel',
-
-		beforeEach: function () {
-			tunnel = new SauceLabsTunnel();
-		},
-
-		getEnvironments: function () {
-			return tunnel.getEnvironments()
-				.then(function (browsers) {
-					assert.isArray(browsers);
-					browsers.forEach(function (environment) {
-						assert.property(environment, 'short_version');
-						assert.property(environment, 'long_name');
-						assert.property(environment, 'api_name');
-						assert.property(environment, 'long_version');
-						assert.property(environment, 'latest_stable_version');
-						assert.property(environment, 'automation_backend');
-						assert.property(environment, 'os');
-					});
-				});
-		},
-
-		parseVersions: (function () {
-			var availableVersionsPromise;
-
-			return {
-				before: function () {
-					availableVersionsPromise = tunnel.getVersions('chrome');
-				},
-
-				latest: function () {
-					return Promise.all([
-						tunnel.parseVersions('latest', 'chrome'),
-						availableVersionsPromise
-					]).then(function (results) {
-						var versions = results[0];
-						var availableVersions = results[1];
-						assert.lengthOf(versions, 1);
-						assert.deepEqual(versions, availableVersions.slice(-1));
-					});
-				},
-
-				'latest - 2 .. latest': function () {
-					return Promise.all([
-						tunnel.parseVersions('latest - 2 .. latest', 'chrome'),
-						availableVersionsPromise
-					]).then(function (results) {
-						var versions = results[0];
-						var availableVersions = results[1];
-						assert.deepEqual(versions, availableVersions.slice(-3));
-					});
-				}
-			};
-		}())
+	var commonTests = createCommonTests(SauceLabsTunnel, {
+		assertDescriptor: assertSauceLabsEnvironment
 	});
+	commonTests.name = 'integration/SauceLabsTunnel';
+	registerSuite(commonTests);
 });

--- a/tests/integration/TestingBotTunnel.js
+++ b/tests/integration/TestingBotTunnel.js
@@ -1,0 +1,67 @@
+define([
+	'intern!object',
+	'intern/chai!assert',
+	'intern/dojo/node!../../TestingBotTunnel',
+	'intern/dojo/Promise'
+], function (
+	registerSuite,
+	assert,
+	TestingBotTunnel,
+	Promise
+) {
+	var tunnel;
+
+	registerSuite({
+		name: 'integration/TestingBotTunnel',
+
+		beforeEach: function () {
+			tunnel = new TestingBotTunnel();
+		},
+
+		getEnvironments: function () {
+			return tunnel.getEnvironments()
+				.then(function (browsers) {
+					assert.isArray(browsers);
+					browsers.forEach(function (environment) {
+						assert.property(environment, 'selenium_name');
+						assert.property(environment, 'name');
+						assert.property(environment, 'platform');
+						assert.property(environment, 'version');
+					});
+				});
+		},
+
+		parseVersions: (function () {
+			var availableVersionsPromise;
+
+			return {
+				before: function () {
+					availableVersionsPromise = tunnel.getVersions('firefox');
+				},
+
+				latest: function () {
+					return Promise.all([
+						tunnel.parseVersions('latest', 'firefox'),
+						availableVersionsPromise
+					]).then(function (results) {
+						var versions = results[0];
+						var availableVersions = results[1];
+						assert.lengthOf(versions, 1);
+						assert.deepEqual(versions, availableVersions.slice(-1));
+					});
+				},
+
+				'latest - 2 .. latest': function () {
+					return Promise.all([
+						tunnel.parseVersions('latest - 2 .. latest', 'firefox'),
+						availableVersionsPromise
+					]).then(function (results) {
+						var versions = results[0];
+						var availableVersions = results[1];
+						assert.deepEqual(versions, availableVersions.slice(-3));
+					});
+				}
+			};
+		}())
+	});
+});

--- a/tests/integration/TestingBotTunnel.js
+++ b/tests/integration/TestingBotTunnel.js
@@ -1,67 +1,24 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
-	'intern/dojo/node!../../TestingBotTunnel',
-	'intern/dojo/Promise'
+	'./common',
+	'intern/dojo/node!../../TestingBotTunnel'
 ], function (
 	registerSuite,
 	assert,
-	TestingBotTunnel,
-	Promise
+	createCommonTests,
+	TestingBotTunnel
 ) {
-	var tunnel;
+	function assertTestingBotEnvironment(environment) {
+		assert.property(environment, 'selenium_name');
+		assert.property(environment, 'name');
+		assert.property(environment, 'platform');
+		assert.property(environment, 'version');
+	}
 
-	registerSuite({
-		name: 'integration/TestingBotTunnel',
-
-		beforeEach: function () {
-			tunnel = new TestingBotTunnel();
-		},
-
-		getEnvironments: function () {
-			return tunnel.getEnvironments()
-				.then(function (browsers) {
-					assert.isArray(browsers);
-					browsers.forEach(function (environment) {
-						assert.property(environment, 'selenium_name');
-						assert.property(environment, 'name');
-						assert.property(environment, 'platform');
-						assert.property(environment, 'version');
-					});
-				});
-		},
-
-		parseVersions: (function () {
-			var availableVersionsPromise;
-
-			return {
-				before: function () {
-					availableVersionsPromise = tunnel.getVersions('firefox');
-				},
-
-				latest: function () {
-					return Promise.all([
-						tunnel.parseVersions('latest', 'firefox'),
-						availableVersionsPromise
-					]).then(function (results) {
-						var versions = results[0];
-						var availableVersions = results[1];
-						assert.lengthOf(versions, 1);
-						assert.deepEqual(versions, availableVersions.slice(-1));
-					});
-				},
-
-				'latest - 2 .. latest': function () {
-					return Promise.all([
-						tunnel.parseVersions('latest - 2 .. latest', 'firefox'),
-						availableVersionsPromise
-					]).then(function (results) {
-						var versions = results[0];
-						var availableVersions = results[1];
-						assert.deepEqual(versions, availableVersions.slice(-3));
-					});
-				}
-			};
-		}())
+	var commonTests = createCommonTests(TestingBotTunnel, {
+		assertDescriptor: assertTestingBotEnvironment
 	});
+	commonTests.name = 'integration/TestingBotTunnel';
+	registerSuite(commonTests);
 });

--- a/tests/integration/all.js
+++ b/tests/integration/all.js
@@ -1,0 +1,6 @@
+define([
+	'./BrowserStackTunnel',
+	'./SauceLabsTunnel',
+	'./TestingBotTunnel'
+], function () {
+});

--- a/tests/integration/common.js
+++ b/tests/integration/common.js
@@ -1,15 +1,24 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
-	'intern/dojo/Promise'
+	'intern/dojo/node!util'
 ], function (
 	registerSuite,
-	assert
+	assert,
+	util
 ) {
 	return function (Tunnel, options) {
 		options = options || { };
 		var metRequirements = false;
 		var tunnel = null;
+
+		function assertNormalizedProperties(environment) {
+			var message = ' undefined for ' + util.inspect(environment.descriptor);
+			assert.isDefined(environment.browserName, 'browserName' + message);
+			assert.isDefined(environment.version, 'version', + message);
+			assert.isDefined(environment.platform, 'platform' + message);
+		}
+
 		var tests = {
 			beforeEach: function () {
 				tests.tunnel = tunnel = new Tunnel();
@@ -25,9 +34,7 @@ define([
 					.then(function (browsers) {
 						assert.isArray(browsers);
 						browsers.forEach(function (environment) {
-							assert.property(environment, 'browserName');
-							assert.property(environment, 'version');
-							assert.property(environment, 'platform');
+							assertNormalizedProperties(environment);
 							assert.property(environment, 'descriptor');
 							options.assertDescriptor(environment.descriptor);
 						});

--- a/tests/integration/common.js
+++ b/tests/integration/common.js
@@ -1,0 +1,40 @@
+define([
+	'intern!object',
+	'intern/chai!assert',
+	'intern/dojo/Promise'
+], function (
+	registerSuite,
+	assert
+) {
+	return function (Tunnel, options) {
+		options = options || { };
+		var metRequirements = false;
+		var tunnel = null;
+		var tests = {
+			beforeEach: function () {
+				tests.tunnel = tunnel = new Tunnel();
+				metRequirements = !options.requirementsCheck || options.requirementsCheck(tunnel);
+			},
+
+			getEnvironments: function () {
+				if (!metRequirements) {
+					this.skip(options.missingRequirementsMessage);
+					return;
+				}
+				return tests.tunnel.getEnvironments()
+					.then(function (browsers) {
+						assert.isArray(browsers);
+						browsers.forEach(function (environment) {
+							assert.property(environment, 'browserName');
+							assert.property(environment, 'version');
+							assert.property(environment, 'platform');
+							assert.property(environment, 'descriptor');
+							options.assertDescriptor(environment.descriptor);
+						});
+					});
+			}
+		};
+		
+		return tests;
+	};
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -10,7 +10,8 @@ define({
 	},
 	reporters: [ 'Console' ],
 	suites: [
-		'dojo/has!host-node?digdug/tests/all'
+		'dojo/has!host-node?digdug/tests/unit',
+		'dojo/has!host-node?digdug/tests/integration/all'
 	],
 	functionalSuites: [],
 	excludeInstrumentation: /^(?:tests|node_modules)\//

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -9,7 +9,8 @@ define([
 	'intern/dojo/node!path',
 	'intern!object',
 	'intern/chai!assert',
-	'intern'
+	'intern',
+	'intern/dojo/Promise'
 ], function (
 	Tunnel,
 	SauceLabsTunnel,
@@ -20,7 +21,8 @@ define([
 	pathUtil,
 	registerSuite,
 	assert,
-	intern
+	intern,
+	Promise
 ) {
 	function cleanup(tunnel) {
 		if (intern.args.noClean) {
@@ -317,8 +319,268 @@ define([
 					tunnel.sendJobState().catch(function () {
 						dfd.resolve();
 					});
-				}
+				},
+
+				'#_resolveVersionAlias': (function () {
+					var versions = [
+						'0',
+						'1',
+						'2',
+						'3',
+						'4'
+					];
+
+					return {
+						'unknown alias; pass-thru': function () {
+							var value = 'unknown';
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, value), value);
+						},
+
+						'single version; pass-thru': function () {
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, '2'), '2');
+						},
+
+						'latest': function () {
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, 'latest'), '4');
+						},
+
+						'previous': function () {
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, 'previous'), '3');
+						},
+
+						'latest-1': function () {
+							var expected = '3';
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, 'latest-1'), expected);
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, 'latest - 1'), expected);
+						},
+
+						'previous-2': function () {
+							assert.strictEqual(tunnel._resolveVersionAlias(versions, 'previous-2'), '1');
+						},
+
+						'alias out of bounds; throws': function () {
+							assert.throws(function () {
+								tunnel._resolveVersionAlias(versions, 'latest-100');
+							});
+						}
+					};
+				}()),
+
+				'#getVersions': {
+					'filters by browser': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{ browser: 'chrome', version: '12' },
+								{ browser: 'firefox', version: '13' }
+							]);
+						};
+
+						return tunnel.getVersions('chrome')
+							.then(function (versions) {
+								assert.lengthOf(versions, 1);
+							});
+					},
+
+					'removes duplicate versions': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{ browser: 'chrome', version: '12' },
+								{ browser: 'chrome', version: '12' }
+							]);
+						};
+
+						return tunnel.getVersions('chrome')
+							.then(function (versions) {
+								assert.lengthOf(versions, 1);
+							});
+					},
+
+					'removes non-numeric versions': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{ browser: 'chrome', version: '12' },
+								{ browser: 'chrome', version: 'beta' },
+								{ browser: 'chrome', version: 'dev' }
+							]);
+						};
+
+						return tunnel.getVersions('chrome')
+							.then(function (versions) {
+								assert.lengthOf(versions, 1);
+								assert.deepEqual(versions, [ '12' ]);
+							});
+					},
+
+					'sorts versions numerically': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{ browser: 'chrome', version: '13' },
+								{ browser: 'chrome', version: '12' }
+							]);
+						};
+
+						return tunnel.getVersions('chrome')
+							.then(function (versions) {
+								assert.lengthOf(versions, 2);
+								assert.strictEqual(versions[0], '12');
+								assert.strictEqual(versions[1], '13');
+							});
+					},
+
+					'works with BrowserStack APIs': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{
+									os: 'Windows',
+									os_version: '8.1',
+									browser: 'chrome',
+									browser_version: '24.0',
+									device: null
+								},
+								{
+									os: 'Windows',
+									os_version: '8.1',
+									browser: 'chrome',
+									browser_version: '25.0',
+									device: null
+								}
+							]);
+						};
+
+						return tunnel.getVersions('chrome')
+							.then(function (versions) {
+								assert.lengthOf(versions, 2);
+								assert.strictEqual(versions[0], '24.0');
+								assert.strictEqual(versions[1], '25.0');
+							});
+					},
+
+					'works with SauceLab APIs': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{
+									selenium_name: 'FF7',
+									name: 'firefox',
+									platform: 'WIN10',
+									version: '7'
+								},
+								{
+									selenium_name: 'FF8',
+									name: 'firefox',
+									platform: 'WIN10',
+									version: '8'
+								}
+							]);
+						};
+
+						return tunnel.getVersions('firefox')
+							.then(function (versions) {
+								assert.lengthOf(versions, 2);
+								assert.strictEqual(versions[0], '7');
+								assert.strictEqual(versions[1], '8');
+							});
+					},
+
+					'works with TestingBot APIs': function () {
+						tunnel.getEnvironments = function () {
+							return Promise.resolve([
+								{
+									short_version: '26',
+									long_name: 'Firefox',
+									api_name: 'firefox',
+									long_version: '26.0b2.',
+									latest_stable_version: '',
+									automation_backend: 'webdriver',
+									os: 'Windows 2003'
+								},
+								{
+									short_version: '25',
+									long_name: 'Firefox',
+									api_name: 'firefox',
+									long_version: '25.0b2.',
+									latest_stable_version: '',
+									automation_backend: 'webdriver',
+									os: 'Windows 2003'
+								}
+							]);
+						};
+
+						return tunnel.getVersions('firefox')
+							.then(function (versions) {
+								assert.lengthOf(versions, 2);
+								assert.strictEqual(versions[0], '25');
+								assert.strictEqual(versions[1], '26');
+							});
+					}
+				},
+
+				'#parseVersions': (function () {
+					return {
+						beforeEach: function () {
+							tunnel.getEnvironments = function () {
+								return Promise.resolve([
+									{ browser: 'chrome', version: '13' },
+									{ browser: 'chrome', version: '12' },
+									{ browser: 'chrome', version: '21' },
+									{ browser: 'Chrome', version: '18' },
+									{ browser: 'Chrome', version: '19' },
+									{ browser: 'firefox', version: '7' },
+									{ browser: 'FireFox', version: '25' }
+								]);
+							};
+						},
+
+						'single version; pass-thru': function () {
+							return tunnel.parseVersions('14', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '14' ]);
+								});
+						},
+
+						'ranged version': function () {
+							return tunnel.parseVersions('14..22', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '18', '19', '21' ]);
+								});
+						},
+
+						'latest keyword': function () {
+							return tunnel.parseVersions('latest', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '21' ]);
+								});
+						},
+
+						'previous keyword': function () {
+							return tunnel.parseVersions('previous', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '19' ]);
+								});
+						},
+
+						'ranged version with alias': function () {
+							return tunnel.parseVersions('15 .. latest', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '18', '19', '21' ]);
+								});
+						},
+
+						'mathed version alias': function () {
+							return tunnel.parseVersions('latest - 1', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '19' ]);
+								});
+						},
+
+						'ranged mathed version alias': function () {
+							return tunnel.parseVersions('latest - 2 .. latest', 'chrome')
+								.then(function (version) {
+									assert.deepEqual(version, [ '18', '19', '21' ]);
+								});
+						}
+					};
+				}())
 			};
-		})()
+		})(),
 	});
 });


### PR DESCRIPTION
Implements #20 

Take a version string which may contain a range or version aliases and returns a list of individual version for use with the tunnel service

Supported version types and ranges:

 * single version: 9
 * ranged version: 9..11
 * latest keyword: latest
 * previous keyword: previous
 * ranged version with alias: 9..latest
 * mathed version alias: latest-2
 * ranged mathed version alias: latest-2...latest