### PR TITLE
Get SC_VERSION from environment, fallback on default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tunnel class                | Environment variables
 ----------------------------|----------------------------------------------------
 `BrowserStackTunnel`        | `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`
 `CrossBrowserTestingTunnel` | `CBT_USERNAME`, `CBT_APIKEY`
-`SauceLabsTunnel`           | `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`, 'SC_VERSION'(optional)
+`SauceLabsTunnel`           | `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`, `SC_VERSION`(optional)
 `TestingBotTunnel`          | `TESTINGBOT_KEY`, `TESTINGBOT_SECRET`
 
 Other properties, such as the local port the tunnel should serve on or the URL of a proxy server the tunnel should go through, can be passed to a tunnel constructor or set on a tunnel instance. See the pages for [Tunnel](Tunnel.html) and the tunnel subclasses for available properties.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tunnel class                | Environment variables
 ----------------------------|----------------------------------------------------
 `BrowserStackTunnel`        | `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`
 `CrossBrowserTestingTunnel` | `CBT_USERNAME`, `CBT_APIKEY`
-`SauceLabsTunnel`           | `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`
+`SauceLabsTunnel`           | `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`, 'SC_VERSION'(optional)
 `TestingBotTunnel`          | `TESTINGBOT_KEY`, `TESTINGBOT_SECRET`
 
 Other properties, such as the local port the tunnel should serve on or the URL of a proxy server the tunnel should go through, can be passed to a tunnel constructor or set on a tunnel instance. See the pages for [Tunnel](Tunnel.html) and the tunnel subclasses for available properties.

--- a/SauceLabsTunnel.js
+++ b/SauceLabsTunnel.js
@@ -11,7 +11,7 @@ var Tunnel = require('./Tunnel');
 var urlUtil = require('url');
 var util = require('./util');
 
-var SC_VERSION = '4.4.1';
+var SC_VERSION = '4.4.2';
 
 /**
  * A Sauce Labs tunnel. This tunnel uses Sauce Connect 4 on platforms where it is supported, and Sauce Connect 3
@@ -22,7 +22,7 @@ var SC_VERSION = '4.4.1';
  */
 function SauceLabsTunnel() {
 	this.accessKey = process.env.SAUCE_ACCESS_KEY;
-	this.scVersion = SC_VERSION;
+	this.scVersion = process.env.SC_VERSION || SC_VERSION;
 	this.directDomains = [];
 	this.tunnelDomains = [];
 	this.domainAuthentication = [];


### PR DESCRIPTION
This PR allows the setting of the SauceConnect version via the environment, defaulting to the version provided in SauceLabsTunnel.js if not present.

The purpose is to allow downstream dependents to set their SauceConnect version without modifying the source, rather than waiting for an updated digdug npm package.

This is currently an issue, as 1.6.2 is the latest version of digdug published to node, with version ~4.3 set for SauceConnect. This version of SauceConnect is no longer compatible with SauceLabs, and is causing issues.

