### PR TITLE
Wait for Sauce Connect to be ready, not just bound to port

### DIFF
--- a/src/SauceLabsTunnel.ts
+++ b/src/SauceLabsTunnel.ts
@@ -401,7 +401,7 @@ export default class SauceLabsTunnel extends Tunnel
         // update the readyfile when the tunnel is ready. Use the
         // 'Selenium listener' message as an alternate startup
         // indicator.
-        if (message.indexOf('Selenium listener started on port ') === 0) {
+        if (message.indexOf('Sauce Connect is up, you may start your tests.') === 0) {
           resolve();
           return true;
         }


### PR DESCRIPTION
For Sauce Connect 4.4.12 on macOS 10.10.13, relying on the readyfile to check startup is not accurate.

Prior to this change, the handler was looking for Sauce Connect to be bound to the Selenium Relay port, which does not indicate readyness.