### PR TITLE
Removes use of the undocumented dev-varnish vm

### DIFF
--- a/src/SauceLabsTunnel.ts
+++ b/src/SauceLabsTunnel.ts
@@ -287,10 +287,7 @@ export default class SauceLabsTunnel extends Tunnel
       '-P',
       this.port,
       '-f',
-      readyFile,
-      // Required for websocket support
-      '--vm-version',
-      'dev-varnish'
+      readyFile
     );
 
     this.directDomains.length && args.push('-D', this.directDomains.join(','));


### PR DESCRIPTION
Tests starting failing with Sauce Labs unable to bring up a machine.  Later got an email from SL saying that they were "planning to remove" undocumented features including dev-varnish setting.  I've removed this code from my local install of DigDug and Intern is now able to run tests against Sauce Labs again.