### PR TITLE
Allow independent proxy url configuration for the browserstack binary

### DIFF
--- a/src/BrowserStackTunnel.ts
+++ b/src/BrowserStackTunnel.ts
@@ -155,10 +155,11 @@ export default class BrowserStackTunnel extends Tunnel
     this.skipServerValidation && args.push('-skipCheck');
     this.tunnelId && args.push('-localIdentifier', this.tunnelId);
     this.verbose && args.push('-v');
+    const aProxy =
+      this.tunnelProxy !== undefined ? this.tunnelProxy : this.proxy;
 
-    if (this.proxy) {
-      const proxy = parseUrl(this.proxy);
-
+    if (aProxy) {
+      const proxy = parseUrl(aProxy);
       proxy.hostname && args.push('-proxyHost', proxy.hostname);
       proxy.port && args.push('-proxyPort', proxy.port);
 

--- a/src/Tunnel.ts
+++ b/src/Tunnel.ts
@@ -103,6 +103,15 @@ export default class Tunnel extends Evented<TunnelEvents, string>
    */
   proxy: string | undefined;
 
+  /**
+   * The URL of a proxy server for the tunnel to go through. Only the
+   * hostname, port, and auth are used.
+   *
+   * This overrides the `proxy` configuration allowing independent
+   * configuration for the Tunnel binary process only.
+   */
+  tunnelProxy!: string | undefined;
+
   /** A unique identifier for the newly created tunnel. */
   tunnelId: string | undefined;
 
@@ -742,6 +751,9 @@ export interface TunnelProperties extends DownloadProperties {
 
   /** [[Tunnel.Tunnel.protocol|More info]] */
   protocol: string;
+
+  /** [[Tunnel.Tunnel.tunnelProxy|More info]] */
+  tunnelProxy: string | undefined;
 
   /** [[Tunnel.Tunnel.tunnelId|More info]] */
   tunnelId: string | undefined;


### PR DESCRIPTION
This commit refers to issue #16 

The original use case was to support using intern and therefore digdug through our HTTP CONNECT proxy.