### PR TITLE
Fix Ctrl-C handling

### DIFF
--- a/src/Tunnel.ts
+++ b/src/Tunnel.ts
@@ -458,8 +458,8 @@ export default class Tunnel extends Evented<TunnelEvents, string>
     let canceled = false;
 
     // Ensure child process is killed when parent exits
+    process.on('SIGINT', () => process.exit(1));
     process.on('exit', () => kill(child.pid));
-    process.on('SIGINT', () => kill(child.pid));
 
     const task = new Task(
       (resolve, reject) => {


### PR DESCRIPTION
Fixes #80 .

When installing a custom SIGINT handler, the default handler is removed.
This means that the process's exit() will not be called.

This is demonstrated fairly simply with this program:
```
process.on('exit', function () { console.log('onexit'); });
process.on('SIGINT', function () { console.log('SIGINT'); });
                                 
setTimeout(function() { console.log('time\'s up'); }, 5000);
```

Adding `process.exit(1)` in the SIGINT handler fixes this.